### PR TITLE
add missing methods for the RegularGridInterpolator

### DIFF
--- a/src/btwxt.h
+++ b/src/btwxt.h
@@ -97,6 +97,14 @@ public:
     grid_data.set_axis_interp_method(dim, method);
   }
 
+  void set_axis_extrap_method(std::size_t dim, Method method) {
+    grid_data.set_axis_extrap_method(dim, method);
+  }
+
+  void set_axis_extrap_limits(std::size_t dim, const std::pair<double, double> &extrap_limits) {
+    grid_data.set_axis_extrap_limits(dim, extrap_limits);
+  }
+
   std::vector<std::vector<short>>& get_hypercube();
 
   std::pair<double, double> get_axis_limits(int dim);


### PR DESCRIPTION
Hei,
consider the following example (based on [scipys RegularGridInterpolator](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html)
```
// Standard
#include <iostream>
#include <numeric>
#include <vector>
#include <math.h>
// btwxt
#include "btwxt.h"
#include "Linspace.h"

using namespace Btwxt;

std::vector<double> f(std::vector<double> x, std::vector<double> y, std::vector<double> z) {
	int d1 = x.size();
	int d2 = y.size();
	int d3 = z.size();
	size_t flat_idx = 0;
	std::vector<double> result(d1*d2*d3);
	for (int i = 0; i < d1; i++) {
		for (int j = 0; j < d2; j++) {
			for (int k = 0; k < d3; k++) {
				flat_idx = i * d2 * d3 + j * d3 + k;
				result[flat_idx] = 2 * std::pow(x[i], 3) + 3 * std::pow(y[j], 2) - z[k];
			}
		}
	}
	return result;
}

void scipy_rgi_example() {
	std::vector<double> x = linspace(1.0, 4.0, 11);
	std::vector<double> y = linspace(4.0, 7.0, 22);
	std::vector<double> z = linspace(7.0, 9.0, 33);
	std::vector<std::vector<double>> data = { f(x, y, z) };

	std::vector<std::vector<double>> vector_grid = {x, y, z};
	RegularGridInterpolator my_interpolating_function(vector_grid, data);

	my_interpolating_function.set_axis_interp_method(0, Method::LINEAR);
	my_interpolating_function.set_axis_interp_method(1, Method::LINEAR);
	my_interpolating_function.set_axis_interp_method(2, Method::LINEAR);

	my_interpolating_function.set_axis_extrap_method(0, Method::LINEAR); // not implemented yet
	my_interpolating_function.set_axis_extrap_limits(1, { 2, 10 });  // not implemented yet

	print_vector(my_interpolating_function({ 2.1, 6.2, 8.3 }));  // 125.805
	print_vector(my_interpolating_function({ 3.3, 5.2, 7.1 }));  // 146.301
}
```
with linspace.h given as
```
#pragma once
#include <iostream>
#include <vector>

//https://gist.github.com/lorenzoriano/5414671
template <typename T>
std::vector<T> linspace(T a, T b, size_t N) {
	T h = (b - a) / static_cast<T>(N - 1);
	std::vector<T> xs(N);
	typename std::vector<T>::iterator x;
	T val;
	for (x = xs.begin(), val = a; x != xs.end(); ++x, val += h)
		*x = val;
	return xs;
}


void print_vector(std::vector<double> vec)
{
	std::cout << "size: " << vec.size() << std::endl;
	for (double d : vec)
		std::cout << d << " ";
	std::cout << std::endl;
}
```

Since `GriddedData grid_data;` is private, I need to set the extrapolation properties via the `RegularGridInterpolator`