### PR TITLE
Check for changed interpolation methods before short-circuiting.

### DIFF
--- a/src/gridpoint.cpp
+++ b/src/gridpoint.cpp
@@ -53,7 +53,7 @@ void GridPoint::set_target(const std::vector<double> &v) {
                 stringify("Target and Gridded Data do not have the same dimensions."));
   }
   if (target_is_set) {
-    if (std::equal(v.begin(), v.end(), target.begin())) {
+    if (std::equal(v.begin(), v.end(), target.begin()) && (methods == grid_data->get_interp_methods())) {
       return;
     }
   }

--- a/test/btwxt_test.cpp
+++ b/test/btwxt_test.cpp
@@ -75,6 +75,20 @@ TEST_F(CubicFixture, spacing_multiplier) {
   EXPECT_DOUBLE_EQ(result, 0.0);
 }
 
+TEST_F(CubicFixture, switch_interp_method) {
+  for (auto i = 0u; i < test_gridded_data.get_ndims(); i++)
+  {
+    test_rgi.set_axis_interp_method(i, Method::CUBIC);
+  }
+  std::vector<double> result1 = test_rgi.get_values_at_target(target);
+  for (auto i = 0u; i < test_gridded_data.get_ndims(); i++)
+  {
+    test_rgi.set_axis_interp_method(i, Method::LINEAR);
+  }
+  std::vector<double> result2 = test_rgi.get_values_at_target(target);
+  EXPECT_NE(result1, result2);
+}
+
 TEST_F(CubicFixture, interpolate) {
   test_rgi.set_new_target(target);
 


### PR DESCRIPTION
If interpolation methods are reset by the client, re-calculate the gridaxes.