### PR TITLE
Add interface library to btwxt

### DIFF
--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -1,7 +1,17 @@
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  if (UNIX)
-    add_definitions("-fPIC")
-  endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
-endif()
+add_library(btwxt_interface_library INTERFACE)
+
+target_compile_options(btwxt_interface_library INTERFACE
+  $<$<CXX_COMPILER_ID:MSVC>: # Visual C++ (VS 2013)
+    /W4   # Warning level (default is W3)
+    #/WX  # Turn warnings into errors
+  >
+
+  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>: # GCC and Clang
+    -Wall       # Turn on all warnings
+    -Wextra     # Turn on extra warnings
+    -Wpedantic  # Turn on warning not covered in Wall and Wextra
+    #-Werror    # Turn warnings into errors
+    -fpic       # Position Independent Code
+  >
+)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,12 +21,7 @@ else()
   add_library(${PROJECT_NAME} SHARED ${library_sources})
 endif()
 
-target_compile_options(btwxt PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>
-  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-  -Wall -Wextra -Wpedantic>
-)
-
+target_link_libraries(${PROJECT_NAME} PRIVATE btwxt_interface_library)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 include(GenerateExportHeader)
 generate_export_header(${PROJECT_NAME})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ set(library_sources
 
 add_executable(${PROJECT_NAME}_tests ${library_sources})
 
-target_link_libraries(${PROJECT_NAME}_tests ${PROJECT_NAME} gtest gmock)
+target_link_libraries(${PROJECT_NAME}_tests PRIVATE ${PROJECT_NAME} gtest gmock btwxt_interface_library)
 
 include(GoogleTest)
 


### PR DESCRIPTION
## Description

The goal was to replace the use of CMAKE global variable for the use of interface library. This way btwxt will follow its users options.

## Changes

- Replace the contents of compiler-flag.cmake for btwxt interface library

## Test

- Ran against the CI
- It created new warnings in the test folder that will need to be clean in the following PR.
