### PR TITLE
Update fmt to version 12.0.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,17 +9,23 @@ jobs:
       matrix:
         include:
           - os: ubuntu
+            os_ver: "latest"
+            config: Release
+            coverage: false
+            cc: gcc-14
+            cxx: g++-14
+          - os: ubuntu
+            os_ver: "22.04"
+            config: Debug
+            coverage: true
+            cc: gcc-11
+            cxx: g++-11
+          - os: ubuntu
             os_ver: "22.04"
             config: Release
             coverage: false
             cc: gcc-11
             cxx: g++-11
-          - os: ubuntu
-            os_ver: "20.04"
-            config: Release
-            coverage: false
-            cc: gcc-10
-            cxx: g++-10
           - os: windows
             os_ver: "2022"
             config: Release
@@ -27,23 +33,19 @@ jobs:
             cc: cl
             cxx: cl
           - os: macos
-            os_ver: "12"
+            os_ver: "15"
             config: Release
             coverage: false
             cc: clang
             cxx: clang++
+            experimental: true
           - os: macos
-            os_ver: "11"
+            os_ver: "26"
             config: Release
             coverage: false
             cc: clang
             cxx: clang++
-          - os: ubuntu
-            os_ver: "20.04"
-            config: Debug
-            coverage: true
-            cc: gcc-10
-            cxx: g++-10
+            experimental: true
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Upstream projects that depend on fmt through btwxt compile with warnings->errors in the older fmt (9.1).